### PR TITLE
Fix unsafe of this inside module initialization (TypeError: Cannot us…

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -4,7 +4,7 @@
   else context[name] = definition()
 }('reqwest', this, function () {
 
-  var context = this
+  var context = this || globalThis
 
   if ('document' in context) {
     var doc = document


### PR DESCRIPTION
…e 'in' operator to search for 'window' in undefined)

when using esbuild with vite. this file generates an exception.
```
TypeError: Cannot use 'in' operator to search for 'window' in undefined
    at reqwest.js:15
    at reqwest.js:8
    at ../node_modules/reqwest/reqwest.js (reqwest.js:10)
    at __require2 (chunk-RDZ5XA5N.js?v=dde87764:17)
    at ../node_modules/auth0-js/index.js (index.js:14)
    at __require2 (chunk-RDZ5XA5N.js?v=dde87764:17)
    at dep:auth0-js:1
```
this usage should've

this is how it looks like when compiled with esbuild+vite. "this" is now referencing a different context than the intended window.

using global this will make it more robust.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis